### PR TITLE
End response process in middleware error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ app.use((err, req, res, next) => {
   res.locals.error = req.app.get('env') === 'development' ? err : {}
 
   // render the error page
-  res.status(err.status || 500)
+  res.status(err.status || 500).end()
 })
 
 app.listen(config.port, () => {


### PR DESCRIPTION
Thanks again for throwing this project together, I think the students really appreciate it.

Think this is the source of the service hang we saw in class. Tested locally by making some malformed requests.

Could also chain `.json()` or `.send()` instead of `.end()`. Whatever strikes your fancy. 😸 