### PR TITLE
Map Item input directly (don't set on value prop)

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -6,7 +6,7 @@ let { Item } = require('../models/item.model.js')
 
 async function AddEditCollection (req, res, next) {
   const { username, collection } = req.params
-  const collectionObject = mapCollection(req.body, res)
+  const collectionObject = mapCollection(req.body)
 
   let searchOptions = { username: username, deleted: { $ne: true } }
   if (req.method === 'PUT') {
@@ -68,7 +68,7 @@ async function AddEditUser (req, res, next) {
   let userData = {
     name: req.body.name,
     username: req.body.username,
-    collections: mapCollections(req.body.collections, res),
+    collections: mapCollections(req.body.collections),
     created_at: req.body.created_at,
     deleted: req.body.deleted
   }
@@ -174,20 +174,14 @@ async function GetDeleteItem (req, res, next) {
 }
 
 /* Model instance utility functions */
-const mapCollections = (collections, res) => collections.map(c => mapCollection(c, res))
-const mapCollection = (collection, res) => {
+const mapCollections = collections => collections.map(c => mapCollection(c))
+const mapCollection = collection => {
   let col = new Collection(collection)
-  col.documents = mapItems(collection.documents, res)
+  col.documents = mapItems(collection.documents)
   return col
 }
-const mapItems = (documents, res) => documents
-  .map(d => new Item(validateItem(d, res)))
-
-const validateItem = (item, res) => {
-  return item.value 
-    ? item
-    : res.status(400).json({ 'error': 400, 'message': 'Items must include a "value" field.' })
-}
+const mapItems = documents => documents
+  .map(d => new Item(d))
 
 router.get('/:username', GetDeleteUser)
 router.post('/', AddEditUser)


### PR DESCRIPTION
ONE MORE TIME WITH FEELING

I misunderstood Items previously. In previous set of changes, mapped user input for document items to new `Item` model's `value` (*see: mapItems func on line 184*). This was actually the weirdness you spotted originally: from me making a `PUT collection` req using the res from a `GET collection` without extracting the `value` fields of each Item, creating unintended nested objects on PUT.

Changes here will treat each document Item in the input as an Item model (must include `value`), like how a collection has `documents`, so Items will always be the same shape between req/res (preserving the other Item fields too, if desired). This is probably what you had in mind, I'm just slow. 🐢 